### PR TITLE
Fix flood protection

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -31,15 +31,12 @@ exports.colors = colors;
 
 const lineDelimiter = new RegExp('\r\n|\r|\n');
 
-const MIN_DELAY_MS = 33;
-
 function Client(server, nick, opt) {
     const self = this;
     /**
      * This promise is used to block new sends until the previous one completes.
      */
     this.sendingPromise = Promise.resolve();
-    this.lastSendTime = 0;
     self.opt = {
         server: server,
         nick: nick,
@@ -1009,26 +1006,20 @@ Client.prototype.disconnect = function(message, callback) {
     this.conn.end();
 };
 
-Client.prototype.send = async function(...command) {
-    let delayPromise = Promise.resolve();
-    if (this.opt.floodProtection) {
-        // Get the amount of time we should wait between messages
-        const delay = this.opt.floodProtectionDelay - Math.min(
-            this.opt.floodProtectionDelay,
-            Date.now() - this.lastSendTime,
-        );
-        if (delay > MIN_DELAY_MS) {
-            delayPromise = new Promise((r) => setTimeout(r, delay));
-        }
+Client.prototype.send = function(...command) {
+    if (!this.opt.floodProtection) {
+        this.sendingPromise = this.sendingPromise.then(() => {
+            this._send(...command);
+        });
+    } else {
+        this.sendingPromise = this.sendingPromise.then(() => {
+            this._send(...command);
+            return new Promise((resolve) => {
+                setTimeout(resolve, this.opt.floodProtectionDelay);
+            });
+        });
     }
-    const currentSendingPromise = this.sendingPromise;
-    const sendPromise = (async () => {
-        await delayPromise;
-        await currentSendingPromise;
-        return this._send(...command);
-    })();
-    this.sendingPromise = sendPromise.finally();
-    return sendPromise;
+    return this.sendingPromise;
 };
 
 Client.prototype._send = function(...cmdArgs) {
@@ -1045,7 +1036,6 @@ Client.prototype._send = function(...cmdArgs) {
     if (this.conn.requestedDisconnect) {
         return;
     }
-    this.lastSendTime = Date.now();
     this.conn.write(args.join(' ') + '\r\n');
 };
 


### PR DESCRIPTION
The flood protection code seems to have been overhauled in https://github.com/matrix-org/node-irc/pull/40. The approach to flood protection taken in that PR seems to be to create a timed promise based on the value of the `lastSendTime` variable, and then to create a new promise which waits on the old send promise and the new timed promise before sending the message and then updating the `lastSendTime` variable.

The problem with this code is that if several calls to the send function are made inside the same event (which is what happens when, for example, hubot responds to the help command and there are several commands in the output, one per line), all of the timed promises made in the send function will be created using the exact same value of the `lastSendTime` variable. The reason for this is that the await calls split the execution flow and put the code after the await call onto the microtask queue, and the microtask queue will not be executed until the current event has finished. So as a result, the `lastSendTime` variable will not be updated at all until all of the timed promises have already been created, and if the time elapsed since `lastSendTime` was updated is greater than the flood protection delay, the timed promises will all be zero seconds long and there will effectively be no flood protection.

The approach to flood protection taken in this commit is to use chained promises which alternate between sending and waiting. The `sendingPromise` field is kept and represents the latest promise in the promise chain. When a new send call is made, it is immediately chained to the previous sending promise and appended with a timed promise that lasts the duration of the flood protection delay. The `sendingPromise` field is then updated to this new promise so that subsequent calls to send can be chained to it. Since we are always appending a timed promise the exact duration of the flood protection delay to the send call, and chaining all subsequent send calls, we don't have to do any math to figure out how much time is left before a message can be sent, and as such, the `lastSendTime` and `MIN_DELAY_MS` variables have been removed.